### PR TITLE
fix bug：slice bounds out of range

### DIFF
--- a/app/aliyun/tool.go
+++ b/app/aliyun/tool.go
@@ -395,6 +395,9 @@ func SubString(str string , begin int ,length int) (substr string) {
 	if begin >= lth {
 		begin = lth
 	}
+	if length < 0 {
+		length = 0
+	}
 	end := begin + length
 	if end > lth {
 		end = lth


### PR DESCRIPTION
任务开始... 

【6999 05-31 上午11.23.25 p2】提取音频文件 ...
【6999 05-31 上午11.23.25 p2】上传音频文件 ...
【6999 05-31 上午11.23.25 p2】上传文件成功 , 识别中 ...
【6999 05-31 上午11.23.25 p2】OSS临时音频清理成功
【6999 05-31 上午11.23.25 p2】错误：runtime error: slice bounds out of range [89:20]


任务完成！

为了避免上面的错误，添加了一个判断
``` golang
	if length < 0 {
		length = 0
	}
```
产生错误的原因是 这个方法的lenght为负数， func SubString(str string , begin int ,length int) (substr string) 
